### PR TITLE
Fix amount formatting to enforce decimal limits

### DIFF
--- a/__mocks__/@react-native-async-storage/async-storage.ts
+++ b/__mocks__/@react-native-async-storage/async-storage.ts
@@ -1,0 +1,5 @@
+export default {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+};

--- a/__mocks__/@react-native-voice/voice.ts
+++ b/__mocks__/@react-native-voice/voice.ts
@@ -1,0 +1,14 @@
+const Voice = {
+  onSpeechStart: jest.fn(),
+  onSpeechResults: jest.fn(),
+  onSpeechError: jest.fn(),
+  removeAllListeners: jest.fn(),
+  start: jest.fn(),
+  stop: jest.fn(),
+  destroy: jest.fn(),
+};
+
+export default Voice;
+export const SpeechResultsEvent = {} as any;
+export const SpeechErrorEvent = {} as any;
+export const SpeechStartEvent = {} as any;

--- a/__mocks__/react-native-get-sms-android.ts
+++ b/__mocks__/react-native-get-sms-android.ts
@@ -1,0 +1,3 @@
+export default {
+  getAll: jest.fn(),
+};

--- a/__mocks__/react-native-vector-icons/Ionicons.ts
+++ b/__mocks__/react-native-vector-icons/Ionicons.ts
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Icon = (props: any) => React.createElement('Icon', props);
+
+export default Icon;

--- a/__tests__/numberUtils.test.ts
+++ b/__tests__/numberUtils.test.ts
@@ -1,0 +1,11 @@
+import { formatAmount } from '../src/utils/numberUtils';
+
+describe('formatAmount', () => {
+  it('formats numbers with thousand separators and two decimals', () => {
+    expect(formatAmount('1234.5678')).toBe('1,234.56');
+  });
+
+  it('handles multiple decimal points', () => {
+    expect(formatAmount('1234.56.78')).toBe('1,234.56');
+  });
+});

--- a/src/utils/numberUtils.ts
+++ b/src/utils/numberUtils.ts
@@ -2,21 +2,22 @@
 export const formatAmount = (value: string): string => {
     // Remove all non-numeric characters except decimal point
     let cleaned = value.replace(/[^0-9.]/g, '');
-    
+
     // Ensure only one decimal point
     const parts = cleaned.split('.');
     if (parts.length > 2) cleaned = parts[0] + '.' + parts[1];
-    
+
+    // Split again after cleaning to work with the updated value
+    let [whole, decimal = ''] = cleaned.split('.');
+
     // Limit to 2 decimal places
-    if (parts.length > 1) {
-      cleaned = parts[0] + '.' + parts[1].slice(0, 2);
+    if (decimal) {
+      decimal = decimal.slice(0, 2);
     }
-  
+
     // Add thousand separators
-    const whole = parts[0];
-    const decimal = parts[1] || '';
     const withCommas = whole.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-    
+
     return decimal ? `${withCommas}.${decimal}` : withCommas;
   };
   


### PR DESCRIPTION
## Summary
- ensure amount formatting recomputes decimals after sanitizing input
- add tests for number formatting edge cases
- mock native modules so Jest can run

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896fb1130f4832d8330d993f0c81def